### PR TITLE
Adds breakpoint-all-map

### DIFF
--- a/scss/pack/mixins/__index.scss
+++ b/scss/pack/mixins/__index.scss
@@ -1,6 +1,7 @@
 // Mixins :: All
 
 @import "./all";
+@import "./all-map";
 @import "./base";
 @import "./down";
 @import "./each";

--- a/scss/pack/mixins/_all-map.scss
+++ b/scss/pack/mixins/_all-map.scss
@@ -1,0 +1,21 @@
+// Mixins :: Breakpoint :: All Map
+
+@mixin breakpoint-all-map($class: false, $map: false, $property: false) {
+  @if $class and $map {
+    @each $breakpoint, $size in $seed-breakpoints {
+      @include breakpoint-up($breakpoint, $seed-breakpoints) {
+        @each $key, $value in $map {
+          $bp_class: #{$class}#{$key};
+          @if $breakpoint != xs {
+            $bp_class: #{$bp_class}--at-#{$breakpoint};
+          }
+          .#{$bp_class} {
+            @if $property {
+              #{$property}: $value;
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Changes
- adds `breakpoint-all-map` mixin

Can be used like this:

``` sass
// Input
$classmap: (
  1: 10px,
  2: 20px
);
@include breakpoint-all-map("classname-", $classmap, font-size);

// Output
.classname-1 {
  font-size: 10px;
}
.classname-2 {
  font-size: 20px;
}
@media (min-width: 544px) {
  .classname-1--at-sm {
    font-size: 10px; }
  .classname-2--at-sm {
    font-size: 20px; }
...
```

Sorta addresses https://github.com/helpscout/seed-breakpoints/issues/2.

This would only be truly useful if Sass supported callback functionality or `@content` variable usage. Unfortunately, [this hasn't happened yet](https://github.com/sass/sass/issues/871)
