### PR TITLE
Updates breakpoint "at" namespace to @

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules/
 bower_components/
 
 npm-debug.log
+dist/

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ Once that is setup, simply `@import` *seed-breakpoints* as needed in your `.scss
 The following variables can be found in [`_config.scss`](https://github.com/helpscout/seed-breakpoints/blob/master/scss/pack/_config.scss)
 
 ```sass
+// Namespaces
+$seed-breakpoints-at-namespace: \@ !default;
+
 // Breakpoints
 $seed-breakpoints: (
   xs: 0,
@@ -61,3 +64,21 @@ $seed-breakpoints: (
 ## Examples
 
 (Coming soon!)
+
+
+## Important updates
+
+#### July 17, 2016
+
+**[Updates breakpoint namespace to @ symbol](https://github.com/helpscout/seed-breakpoints/pull/9)**
+
+This change was made to better follow the ITCSS naming conventions for [responsive classes](http://csswizardry.com/2015/08/bemit-taking-the-bem-naming-convention-a-step-further/).
+
+The compiled stylesheet (`.css`) will show the classes like:
+`.class\@sm { ... }`
+
+However, your markup can just be:
+`<div class="class@sm">...</div>`
+
+From this version forward, scss code utilizing the breakpoint mixins will now have altered (default) compiled responsive classes.
+If you prefer using the older `--at-size` convention (or establish your own personal conventions), you can modify the new `$seed-breakpoints-at-namespace` variable.

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "main": "index.js",
   "homepage": "https://github.com/helpscout/seed-breakpoints",
   "scripts": {
-    "build": "npm run build:test",
-    "build:test": "node-sass --include-path node_modules/seed-props/scss scss/pack/_seed-breakpoints.scss dist/seed-breakpoints.css",
-    "test": "node ./scripts/test.js",
+    "banner": "node ./scripts/banner.js",
+    "build": "npm run build:main && npm run banner",
+    "build:main": "node ./scripts/build.js",
+    "test": "node ./scripts/test.js && npm run build",
     "prepublish": "npm run test"
   },
   "repository": {

--- a/scripts/banner.js
+++ b/scripts/banner.js
@@ -1,0 +1,34 @@
+var fs = require('fs');
+var pkg = require('../package.json');
+
+var banner = ['/**',
+  ' * '+ pkg.name +' v'+ pkg.version +' ('+ pkg.homepage +')',
+  ' * '+ pkg.description,
+  ' * Licensed under '+ pkg.license,
+  ' */',
+  ''].join('\n');
+
+var dir = './dist/';
+
+fs.readdir(dir, function(err, files) {
+  if (err) {
+    console.error('Could not list the directory.', err);
+    process.exit(1);
+  }
+
+  files.forEach(function(file, index) {
+    fs.readFile(dir + file, 'utf-8', function(err, data) {
+      if (err) {
+        return console.log(err);
+      }
+
+      data = banner + data;
+
+      fs.writeFile(dir + file, data, 'utf-8', function(err) {
+        if (err) {
+          return console.log(err);
+        }
+      });
+    });
+  });
+});

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,51 @@
+'use strict';
+
+var pkg = require('../package.json');
+var fs = require('fs');
+var mkdirp = require('mkdirp');
+var pathfinder = require('./pathfinder');
+var sass = require('node-sass');
+
+var file = pkg.name;
+var includePaths = pathfinder(
+  require('seed-props')
+);
+
+// Default .css compile
+sass.render({
+  file: './scss/pack/'+file+'/__index.scss',
+  includePaths: includePaths
+}, function(error, result) {
+  if (error) {
+    console.error(error);
+    return process.exit(1);
+  }
+  else {
+    mkdirp('./dist');
+    fs.writeFile('./dist/'+file+'.css', result.css, function(err){
+      if(!err){
+        return console.log(file+'.css created.');
+      }
+    })
+  }
+});
+
+// Minified .css compile
+sass.render({
+  file: './scss/pack/'+file+'/__index.scss',
+  includePaths: includePaths,
+  outputStyle: 'compressed'
+}, function(error, result) {
+  if (error) {
+    console.error(error);
+    return process.exit(1);
+  }
+  else {
+    mkdirp('./dist');
+    fs.writeFile('./dist/'+file+'.min.css', result.css, function(err){
+      if(!err){
+        return console.log(file+'.min.css created.');
+      }
+    })
+  }
+});

--- a/scss/pack/seed-breakpoints/_config.scss
+++ b/scss/pack/seed-breakpoints/_config.scss
@@ -1,7 +1,9 @@
 // Seed Breakpoints :: Config
 
+// Namespaces
 $seed-breakpoints-at-namespace: \@ !default;
 
+// Breakpoints
 $seed-breakpoints: (
   xs: 0,
   sm: 544px,

--- a/scss/pack/seed-breakpoints/_config.scss
+++ b/scss/pack/seed-breakpoints/_config.scss
@@ -1,5 +1,7 @@
 // Seed Breakpoints :: Config
 
+$seed-breakpoints-at-namespace: \@ !default;
+
 $seed-breakpoints: (
   xs: 0,
   sm: 544px,

--- a/scss/pack/seed-breakpoints/mixins/_all.scss
+++ b/scss/pack/seed-breakpoints/mixins/_all.scss
@@ -9,7 +9,7 @@
     }
     @else {
       @include breakpoint($name) {
-        &--at-#{$name} {
+        &#{$seed-breakpoints-at-namespace}#{$name} {
           @content;
         }
       }

--- a/scss/pack/seed-breakpoints/mixins/_down.scss
+++ b/scss/pack/seed-breakpoints/mixins/_down.scss
@@ -7,7 +7,7 @@
     }
     @else {
       @include breakpoint-max($name) {
-        &--at-#{$name} {
+        &#{$seed-breakpoints-at-namespace}#{$name} {
           @content;
         }
       }

--- a/scss/pack/seed-breakpoints/mixins/_each.scss
+++ b/scss/pack/seed-breakpoints/mixins/_each.scss
@@ -6,7 +6,7 @@
   @each $name, $breakpoint in $seed-breakpoints {
     @if($breakpoint != 0) {
       @include breakpoint($name) {
-        &--at-#{$name} {
+        &#{$seed-breakpoints-at-namespace}#{$name} {
           @content;
         }
       }

--- a/scss/pack/seed-breakpoints/mixins/_prop-map.scss
+++ b/scss/pack/seed-breakpoints/mixins/_prop-map.scss
@@ -10,7 +10,7 @@
     }
     @else {
       @include breakpoint($name) {
-        $class_suffix: --at-#{$name};
+        $class_suffix: #{$seed-breakpoints-at-namespace}#{$name};
         @include prop-map($map, $properties, $class_suffix) {
           @content;
         }


### PR DESCRIPTION
### Changes
- adds $seed-breakpoints-at-namespace variable
- sets namespace variable to @ symbol
- updates mixins to use at-namespace
- adds/updates seed build scripts

This change was made to better follow the ITCSS naming conventions for [responsive classes](http://csswizardry.com/2015/08/bemit-taking-the-bem-naming-convention-a-step-further/).

The compiled stylesheet (`.css`) will show the classes like:
`.class\@sm { ... }`

However, your markup can just be:
`<div class="class@sm">...</div>`
#### Note

From this version forward, scss code utilizing the breakpoint mixins will now have altered (default) compiled responsive classes.

If you prefer using the older `--at-size` convention (or establish your own personal conventions), you can modify the new `$seed-breakpoints-at-namespace` variable.
