### PR TITLE
Adds custom breakpoint argument + new mixins

### DIFF
--- a/scss/pack/seed-breakpoints/mixins/__index.scss
+++ b/scss/pack/seed-breakpoints/mixins/__index.scss
@@ -2,7 +2,10 @@
 
 @import "./all";
 @import "./base";
+@import "./between";
 @import "./down";
 @import "./each";
 @import "./prop-map";
+@import "./max";
+@import "./min";
 @import "./up";

--- a/scss/pack/seed-breakpoints/mixins/_base.scss
+++ b/scss/pack/seed-breakpoints/mixins/_base.scss
@@ -1,11 +1,16 @@
 // Mixins :: Breakpoint :: Base
 
-// Available breakpoint sizes
-// xs, sm, md, lg, xl
-@mixin breakpoint($name, $breakpoints: $seed-breakpoints) {
-  @if map-has-key($breakpoints, $name) {
-    @media (min-width: #{map-get($breakpoints, $name)}) {
+@mixin breakpoint($value, $breakpoints: $seed-breakpoints) {
+  @if map-has-key($breakpoints, $value) {
+    @media (min-width: #{map-get($breakpoints, $value)}) {
       @content;
+    }
+  }
+  @else {
+    @if type-of($value) == "number" {
+      @media (min-width: $value) {
+        @content;
+      }
     }
   }
 }

--- a/scss/pack/seed-breakpoints/mixins/_between.scss
+++ b/scss/pack/seed-breakpoints/mixins/_between.scss
@@ -1,0 +1,33 @@
+// Mixins :: Breakpoint-between
+
+@mixin breakpoint-between($min: false, $max: false, $breakpoints: $seed-breakpoints) {
+  @if $min == false or $max == false {
+    @error "breakpoint-between: The first argument (min) and second argument (max) must be defined.";
+  }
+  
+  $map-min: false;
+  $map-max: false;
+
+  @if map-has-key($breakpoints, $min) {
+    $map-min: map-get($breakpoints, $min);
+  }
+  @if map-has-key($breakpoints, $max) {
+    $map-max: map-get($breakpoints, $max);
+  }
+  @if not $map-min {
+    @if type-of($min) == "number" {
+      $map-min: $min;
+    }
+  }
+  @if not $map-max {
+    @if type-of($max) == "number" {
+      $map-max: $max;
+    }
+  }
+
+  @if $map-min and $map-max {
+    @media (min-width: $map-min) and (max-width: $map-max) {
+      @content;
+    }
+  }
+}

--- a/scss/pack/seed-breakpoints/mixins/_max.scss
+++ b/scss/pack/seed-breakpoints/mixins/_max.scss
@@ -1,0 +1,16 @@
+// Mixins :: Breakpoint-Max
+
+@mixin breakpoint-max($value, $breakpoints: $seed-breakpoints) {
+  @if map-has-key($breakpoints, $value) {
+    @media (max-width: #{map-get($breakpoints, $value)}) {
+      @content;
+    }
+  }
+  @else {
+    @if type-of($value) == "number" {
+      @media (max-width: $value) {
+        @content;
+      }
+    }
+  }
+}

--- a/scss/pack/seed-breakpoints/mixins/_min.scss
+++ b/scss/pack/seed-breakpoints/mixins/_min.scss
@@ -1,0 +1,8 @@
+// Mixins :: Breakpoint-min
+// Alias of :: @mixin breakpoint
+
+@mixin breakpoint-min($arguments...) {
+  @include breakpoint($arguments...) {
+    @content;
+  }
+}


### PR DESCRIPTION
- adds breakpoint-max, breakpoint-min, and breakpoint-between mixins
- certain breakpoint mixins now accept custom numbers as arguments (px, em, rem)

The following examples are now acceptable:
(Note the flexibility of the argument(s) passed)

```
@include breakpoint(500px) {
  ...
}

@include breakpoint-max(lg) {
  ...
}

@include breakpoint-min(5em) {
  ...
}

@include breakpoint-between(sm, 821px) {
  ...
}
```

Addresses:
https://github.com/helpscout/seed-breakpoints/issues/1
https://github.com/helpscout/seed-breakpoints/issues/7
