### PR TITLE
Fixes the max-width for max/between mixins

### DIFF
--- a/scss/pack/seed-breakpoints/mixins/_between.scss
+++ b/scss/pack/seed-breakpoints/mixins/_between.scss
@@ -4,7 +4,7 @@
   @if $min == false or $max == false {
     @error "breakpoint-between: The first argument (min) and second argument (max) must be defined.";
   }
-  
+
   $map-min: false;
   $map-max: false;
 
@@ -13,6 +13,10 @@
   }
   @if map-has-key($breakpoints, $max) {
     $map-max: map-get($breakpoints, $max);
+
+    @if $map-max {
+      $map-max: $map-max - 1px;
+    }
   }
   @if not $map-min {
     @if type-of($min) == "number" {

--- a/scss/pack/seed-breakpoints/mixins/_max.scss
+++ b/scss/pack/seed-breakpoints/mixins/_max.scss
@@ -2,7 +2,7 @@
 
 @mixin breakpoint-max($value, $breakpoints: $seed-breakpoints) {
   @if map-has-key($breakpoints, $value) {
-    @media (max-width: #{map-get($breakpoints, $value)}) {
+    @media (max-width: #{map-get($breakpoints, $value)} - 1px) {
       @content;
     }
   }


### PR DESCRIPTION
The calculations were 1px off. If the breakpoint exists, the max width needs to be $max-width - 1px.

Bootstrap v4 breakpoint docs have some good examples of this:
http://v4-alpha.getbootstrap.com/layout/overview/#responsive-breakpoints

This issue was first spotted by @jaredmcdaniel 

Note: This `1px` offset only applies to breakpoints specified in `$seed-breakpoints`. If you pass in a custom number, it will use that number exactly.

---

Before:

``` scss
// .scss
.class {
  @include breakpoint-max(md) {
    ...
  }
}

// .css
.class {
  @media (max-width: 768px) {
    ...
  }
}
```

After:

``` scss
// .scss
.class {
  @include breakpoint-max(md) {
    ...
  }
}

// .css
.class {
  @media (max-width: 767px) {
    ...
  }
}
```
